### PR TITLE
bump murmur3 to v1.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/shirou/gopsutil v0.0.0-20190627142359-4c8b404ee5c5
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 // indirect
-	github.com/twmb/murmur3 v0.0.0-20190212075929-930dc7964b30
+	github.com/twmb/murmur3 v1.1.1
 	github.com/willf/bitset v1.1.10 // indirect
 	github.com/willf/bloom v2.0.3+incompatible
 	gopkg.in/yaml.v2 v2.2.2


### PR DESCRIPTION
murmur3 included unsafe code; go1.14 has a -d=checkptr flag that checks
some uses of unsafe code. Turns out, the original usage of murmur3 was
unsafe due to alignment issues.

This does not affect the murmur128 assembly code because unaligned reads
on amd64 are safe (although slower, but we don't usually expect the hash
to have unaligned input).

This bumps the dep to pull in the fixes.