### PR TITLE
Metrics Query/Graph Fixes

### DIFF
--- a/.copr/gudgeon.spec.template
+++ b/.copr/gudgeon.spec.template
@@ -36,7 +36,7 @@ fi
 
 # install newer version of node locally if not over v8
 NPMVSORT=$(echo -e "$(nodejs --version || node --version || echo 'v0.0.0')\nv12.0.0" | sort -V | tail -n1)
-if [[ "v8.0.0" == "${NPMVSORT}" ]]; then
+if [[ "v12.0.0" == "${NPMVSORT}" ]]; then
     # architecture
     NODEARCH=$(echo "$LOCALARCH" | sed 's/amd64/x64/')
 

--- a/engine/metrics.go
+++ b/engine/metrics.go
@@ -365,7 +365,8 @@ func (metrics *metrics) QueryFunc(accumulatorFunction MetricsAccumulator, option
 	var err error
 	var query *sql.Stmt
 
-	optionsQueryKey := fmt.Sprint("%s:step=%d", options.ChosenMetrics, options.StepSize)
+	// create an options query key for a given metric pattern with a corresponding step size
+	optionsQueryKey := fmt.Sprintf("%s:step=%d", options.ChosenMetrics, options.StepSize)
 
 	// try and get query from prepared cache
 	if value, found := metrics.queryCache.Get(optionsQueryKey); found {


### PR DESCRIPTION
- Added a scaling factor that skips rows based on a modulus to allow lower resolution in queries that return more metrics (better performance on graphing)
- Fixed a long-standing (unnoticed) defect in engine/metrics.go that was causing the requested/chosen metrics to not be passed to the query layer resulting in more than the requested metrics being returned